### PR TITLE
docs(i18n): translate simulation guides

### DIFF
--- a/docs/source/zh-hans/_toctree.yml
+++ b/docs/source/zh-hans/_toctree.yml
@@ -41,6 +41,12 @@
     title: 实时分块（RTC）
   title: "推理"
 - sections:
+  - local: envhub
+    title: 从 Hub 加载环境
+  - local: envhub_leisaac
+    title: LeIsaac × LeRobot EnvHub
+  title: "仿真"
+- sections:
   - local: notebooks
     title: Notebooks
   - local: feetech

--- a/docs/source/zh-hans/envhub.mdx
+++ b/docs/source/zh-hans/envhub.mdx
@@ -1,0 +1,430 @@
+# 从 Hub 加载环境
+
+**EnvHub** 功能支持通过一行代码直接从 Hugging Face Hub 加载仿真环境。这带来了一种新的协作方式：环境不再只能封装在大型单体库中，任何人都可以发布自定义环境并与社区共享。
+
+## EnvHub 是什么？
+
+EnvHub 支持使用自定义机器人模型和场景创建机器人仿真环境，并通过 LeRobot 框架让其他人轻松使用。
+
+EnvHub 环境包存储在 Hugging Face Hub 上，可以通过 LeRobot 无缝拉取并用于 AI 机器人项目，只需一行代码。
+
+借助 EnvHub，可以：
+
+1. **创建环境并发布到 Hugging Face Hub**：将环境作为 Git 仓库发布，无需处理复杂的打包流程即可分发复杂的物理仿真
+2. **动态加载环境**：无需将环境安装为软件包
+3. **使用 Git 语义管理版本并跟踪环境变化**
+4. **发现**社区共享的新仿真任务
+
+这意味着，可以在几秒内完成从 Hub 发现感兴趣的环境到运行实验的过程，也可以创建自定义机器人和环境，无需担心依赖冲突或复杂的安装流程。
+
+创建 EnvHub 环境包时，可以在其中构建任意内容，并使用任意仿真工具。这是一个可自由探索的空间。唯一要求是，环境包必须包含 `env.py` 文件，用于定义环境，以便 LeRobot 加载和使用 EnvHub 环境包。
+
+`env.py` 文件需要暴露一个简洁的 API，以便 LeRobot 加载并运行环境。具体而言，必须提供以下函数之一：`make_env(n_envs: int = 1, use_async_envs: bool = False)` 或 `make_env(n_envs: int = 1, use_async_envs: bool = False, cfg: EnvConfig)`。这是 LeRobot 的主要入口。函数应返回以下对象之一：
+
+- `gym.vector.VectorEnv`（最常见）
+- 单个 `gym.Env`（会自动包装）
+- 映射 `{suite_name: {task_id: VectorEnv}}` 的字典（用于多任务基准测试）
+
+也可以向 `make_env` 传入 `EnvConfig` 对象来配置环境，例如环境数量、任务、摄像头名称、初始状态、控制模式和 episode 时长等。
+
+最后，环境必须实现标准的 `gym.vector.VectorEnv` 接口，才能与 LeRobot 配合使用，包括 `reset` 和 `step` 等方法。
+
+## 快速开始
+
+从 Hub 加载环境非常简单：
+
+```python
+from lerobot.envs import make_env
+
+# 加载 Hub 环境（需要明确同意执行远程代码）
+env = make_env("lerobot/cartpole-env", trust_remote_code=True)
+```
+
+<Tip warning={true}>
+  **安全提示：** 从 Hub 加载环境会执行第三方仓库中的 Python
+  代码。只有在确认仓库可信时，才应使用
+  `trust_remote_code=True`。强烈建议固定到特定的提交哈希，以确保可复现性和安全性。
+</Tip>
+
+## 仓库结构
+
+要让环境可以从 Hub 加载，仓库至少必须包含以下内容：
+
+### 必需文件
+
+**`env.py`**（或自定义 Python 文件）
+
+- 必须暴露 `make_env(n_envs: int, use_async_envs: bool)` 函数
+- 函数应返回以下对象之一：
+  - `gym.vector.VectorEnv`（最常见）
+  - 单个 `gym.Env`（会自动包装）
+  - 映射 `{suite_name: {task_id: VectorEnv}}` 的字典（用于多任务基准测试）
+
+### 可选文件
+
+**`requirements.txt`**
+
+- 列出环境所需的其他依赖
+- 在加载环境前，需要由环境使用者手动安装这些依赖
+
+**`README.md`**
+
+- 说明环境的任务、观测空间和动作空间、奖励等内容
+- 包含使用示例和特殊设置说明
+
+**`.gitignore`**
+
+- 排除仓库中不需要的文件
+
+### 仓库结构示例
+
+```
+my-environment-repo/
+├── env.py                 # 环境主定义文件（必需）
+├── requirements.txt       # 依赖（可选）
+├── README.md              # 文档（建议提供）
+├── assets/                # 图片、视频等（可选）
+│   └── demo.gif
+└── configs/              # 配置文件（按需提供，可选）
+    └── task_config.yaml
+```
+
+## 创建环境仓库
+
+### 第一步：定义环境
+
+创建 `env.py` 文件，并在其中定义 `make_env` 函数：
+
+```python
+# env.py
+import gymnasium as gym
+
+def make_env(n_envs: int = 1, use_async_envs: bool = False):
+    """
+    为自定义任务创建向量化环境。
+
+    参数：
+        n_envs：并行环境数量
+        use_async_envs：是否使用 AsyncVectorEnv 而不是 SyncVectorEnv
+
+    返回：
+        gym.vector.VectorEnv，或映射套件名称到向量化环境的字典
+    """
+    def _make_single_env():
+        # 创建自定义环境
+        return gym.make("CartPole-v1")
+
+    # 选择向量化环境类型
+    env_cls = gym.vector.AsyncVectorEnv if use_async_envs else gym.vector.SyncVectorEnv
+
+    # 创建向量化环境
+    vec_env = env_cls([_make_single_env for _ in range(n_envs)])
+
+    return vec_env
+```
+
+### 第二步：在本地测试
+
+上传前，请在本地测试环境：
+
+```python
+from lerobot.envs.utils import _load_module_from_path, _call_make_env, _normalize_hub_result
+
+# 加载模块
+module = _load_module_from_path("./env.py")
+
+# 测试 make_env 函数
+result = _call_make_env(module, n_envs=2, use_async_envs=False)
+normalized = _normalize_hub_result(result)
+
+# 验证环境是否正常运行
+suite_name = next(iter(normalized))
+env = normalized[suite_name][0]
+obs, info = env.reset()
+print(f"Observation shape: {obs.shape if hasattr(obs, 'shape') else type(obs)}")
+env.close()
+```
+
+### 第三步：上传到 Hub
+
+将仓库上传到 Hugging Face：
+
+```bash
+# 如有需要，安装 huggingface_hub
+pip install huggingface_hub
+
+# 登录 Hugging Face
+hf auth login
+
+# 创建新仓库
+hf repo create my-org/my-custom-env
+
+# 初始化 Git 并推送
+git init
+git add .
+git commit -m "Initial environment implementation"
+git remote add origin https://huggingface.co/my-org/my-custom-env
+git push -u origin main
+```
+
+也可以使用 `huggingface_hub` Python API：
+
+```python
+from huggingface_hub import HfApi
+
+api = HfApi()
+
+# 创建仓库
+api.create_repo("my-custom-env", repo_type="space")
+
+# 上传文件
+api.upload_folder(
+    folder_path="./my-env-folder",
+    repo_id="username/my-custom-env",
+    repo_type="space",
+)
+```
+
+## 从 Hub 加载环境
+
+### 基本用法
+
+```python
+from lerobot.envs import make_env
+
+# 从 Hub 加载
+envs_dict = make_env(
+    "username/my-custom-env",
+    n_envs=4,
+    trust_remote_code=True
+)
+
+# 访问环境
+suite_name = next(iter(envs_dict))
+env = envs_dict[suite_name][0]
+
+# 像使用普通 gym 环境一样使用
+obs, info = env.reset()
+action = env.action_space.sample()
+obs, reward, terminated, truncated, info = env.step(action)
+```
+
+### 高级用法：固定特定版本
+
+为了保证可复现性和安全性，可以固定到特定的 Git 修订版本：
+
+```python
+# 固定到特定分支
+env = make_env("username/my-env@main", trust_remote_code=True)
+
+# 固定到特定提交（论文和实验建议使用）
+env = make_env("username/my-env@abc123def456", trust_remote_code=True)
+
+# 固定到标签
+env = make_env("username/my-env@v1.0.0", trust_remote_code=True)
+```
+
+### 自定义文件路径
+
+如果环境定义不在 `env.py` 中：
+
+```python
+# 从自定义文件加载
+env = make_env("username/my-env:custom_env.py", trust_remote_code=True)
+
+# 结合版本固定
+env = make_env("username/my-env@v1.0:envs/task_a.py", trust_remote_code=True)
+```
+
+### 异步环境
+
+对于多个环境，可以使用异步环境来获得更好的性能：
+
+```python
+envs_dict = make_env(
+    "username/my-env",
+    n_envs=8,
+    use_async_envs=True,  # 使用 AsyncVectorEnv 并行执行
+    trust_remote_code=True
+)
+```
+
+## URL 格式参考
+
+Hub URL 支持以下几种格式：
+
+| 格式                 | 说明                  | 示例                                   |
+| -------------------- | --------------------- | -------------------------------------- |
+| `user/repo`          | 从主分支加载 `env.py` | `make_env("lerobot/pusht-env")`        |
+| `user/repo@revision` | 从特定修订版本加载    | `make_env("lerobot/pusht-env@main")`   |
+| `user/repo:path`     | 加载自定义文件        | `make_env("lerobot/envs:pusht.py")`    |
+| `user/repo@rev:path` | 修订版本 + 自定义文件 | `make_env("lerobot/envs@v1:pusht.py")` |
+
+## 多任务环境
+
+对于包含多个任务的基准测试（例如 LIBERO），应返回嵌套字典：
+
+```python
+def make_env(n_envs: int = 1, use_async_envs: bool = False):
+    env_cls = gym.vector.AsyncVectorEnv if use_async_envs else gym.vector.SyncVectorEnv
+
+    # 返回字典：{suite_name: {task_id: VectorEnv}}
+    return {
+        "suite_1": {
+            0: env_cls([lambda: gym.make("Task1-v0") for _ in range(n_envs)]),
+            1: env_cls([lambda: gym.make("Task2-v0") for _ in range(n_envs)]),
+        },
+        "suite_2": {
+            0: env_cls([lambda: gym.make("Task3-v0") for _ in range(n_envs)]),
+        }
+    }
+```
+
+## 安全注意事项
+
+<Tip warning={true}>
+  **重要提示：** 要执行来自 Hub 的环境代码，必须设置
+  `trust_remote_code=True`。这是出于安全考虑的设计。
+</Tip>
+
+从 Hub 加载环境时：
+
+1. **先检查代码**：访问仓库，在加载前检查 `env.py`
+2. **固定到提交**：使用特定的提交哈希以确保可复现
+3. **检查依赖**：检查 `requirements.txt` 中是否存在可疑软件包
+4. **使用可信来源**：优先选择官方组织或知名研究人员发布的环境
+5. **按需使用沙箱**：在隔离环境（容器、虚拟机）中运行不可信代码
+
+安全用法示例：
+
+```python
+# ❌ 不安全：未检查就加载远程代码
+env = make_env("random-user/untrusted-env", trust_remote_code=True)
+
+# ✅ 安全：检查代码后固定到特定提交
+# 1. 访问 https://huggingface.co/trusted-org/verified-env
+# 2. 检查 env.py 文件
+# 3. 复制提交哈希
+env = make_env("trusted-org/verified-env@a1b2c3d4", trust_remote_code=True)
+```
+
+## 示例：从 Hub 加载 CartPole
+
+下面是使用参考 CartPole 环境的完整示例：
+
+```python
+from lerobot.envs import make_env
+import numpy as np
+
+# 加载环境
+envs_dict = make_env("lerobot/cartpole-env", n_envs=4, trust_remote_code=True)
+
+# 获取向量化环境
+suite_name = next(iter(envs_dict))
+env = envs_dict[suite_name][0]
+
+# 运行一个简单的 episode
+obs, info = env.reset()
+done = np.zeros(env.num_envs, dtype=bool)
+total_reward = np.zeros(env.num_envs)
+
+while not done.all():
+    # 随机策略
+    action = env.action_space.sample()
+    obs, reward, terminated, truncated, info = env.step(action)
+    total_reward += reward
+    done = terminated | truncated
+
+print(f"Average reward: {total_reward.mean():.2f}")
+env.close()
+```
+
+## EnvHub 的优势
+
+### 对环境作者
+
+- **分发简单**：无需 PyPI 打包
+- **版本控制**：使用 Git 管理环境版本
+- **快速迭代**：立即推送更新
+- **文档支持**：Hub README 可以直接渲染
+- **触达社区**：直接接触 LeRobot 用户
+
+### 对研究人员
+
+- **快速实验**：一行代码加载任意环境
+- **可复现性**：固定到特定提交
+- **环境发现**：浏览 Hub 上的环境
+- **无冲突**：无需安装相互冲突的软件包
+
+### 对社区
+
+- **生态不断发展**：更多样化的仿真任务
+- **标准化**：统一的 `make_env` API
+- **协作**：Fork 并改进现有环境
+- **易于参与**：降低共享研究成果的门槛
+
+## 故障排除
+
+### 「Refusing to execute remote code」
+
+必须显式传入 `trust_remote_code=True`：
+
+```python
+env = make_env("user/repo", trust_remote_code=True)
+```
+
+### 「Module X not found」
+
+Hub 环境依赖需要手动安装：
+
+```bash
+# 检查仓库的 requirements.txt 并安装依赖
+pip install gymnasium numpy
+```
+
+### 「make_env not found in module」
+
+`env.py` 必须暴露 `make_env` 函数：
+
+```python
+def make_env(n_envs: int, use_async_envs: bool):
+    # 自定义实现
+    pass
+```
+
+### 环境返回类型错误
+
+`make_env` 函数必须返回以下对象之一：
+
+- `gym.vector.VectorEnv`
+- 单个 `gym.Env`
+- 字典 `{suite_name: {task_id: VectorEnv}}`
+
+## 最佳实践
+
+1. **记录环境文档**：在 README 中说明观测空间、动作空间、奖励结构和终止条件
+2. **添加 requirements.txt**：列出所有依赖及其版本
+3. **充分测试**：推送前在本地验证环境可以正常运行
+4. **使用语义化版本**：使用版本号标记发布版本
+5. **添加示例**：在 README 中包含使用示例
+6. **保持简单**：尽量减少依赖
+7. **添加许可证**：添加 LICENSE 文件以明确使用条款
+
+## 未来方向
+
+EnvHub 生态支持以下发展方向：
+
+- **GPU 加速物理仿真**：共享 Isaac Gym 或 Brax 环境
+- **照片级渲染**：分发带有高级图形效果的环境
+- **多智能体场景**：复杂的交互任务
+- **真实世界仿真器**：物理系统的数字孪生
+- **程序化生成**：无限任务变化
+- **域随机化**：预配置的 DR 流程
+
+随着更多研究人员和开发者参与，环境的多样性和质量将不断提高，让整个机器人学习社区受益。
+
+## 另请参阅
+
+- [Hugging Face Hub 文档](https://huggingface.co/docs/hub/en/index)
+- [Gymnasium 文档](https://gymnasium.farama.org/index.html)
+- [Hub 环境示例](https://huggingface.co/lerobot/cartpole-env)

--- a/docs/source/zh-hans/envhub_leisaac.mdx
+++ b/docs/source/zh-hans/envhub_leisaac.mdx
@@ -1,0 +1,300 @@
+# LeIsaac × LeRobot EnvHub
+
+LeRobot EnvHub 现已支持通过 LeIsaac 在仿真中进行**模仿学习**。启动日常操作任务、遥操作机器人、采集示范、将数据推送到 Hub，并在 LeRobot 中训练策略——全部可以在同一流程中完成。
+
+[LeIsaac](https://github.com/LightwheelAI/leisaac) 与 IsaacLab 以及 SO101 Leader/Follower 设置集成，提供以下能力：
+
+- 🕹️ **以遥操作为主的数据采集流程**
+- 📦 **内置数据转换**，可直接用于 LeRobot 训练
+- 🤖 **日常操作技能**，例如拾取橙子、抬起方块、清理桌面和折叠布料
+- ☁️ [LightWheel](https://lightwheel.ai/) **持续升级**：云端仿真、EnvHub 支持、Sim2Real 工具等
+
+下面列出目前通过 LeRobot EnvHub 支持的 LeIsaac 任务。
+
+# 可用环境
+
+下表列出了 LeIsaac × LeRobot EnvHub 中的所有可用任务和环境。也可以运行以下命令获取最新环境列表：
+
+```bash
+python scripts/environments/list_envs.py
+```
+
+| 任务                                                                                                                                                            | 环境 ID                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                       | 任务描述                                                                                                  | 相关机器人                                         |
+| :-------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :-------------------------------------------------------------------------------------------------------- | :------------------------------------------------- |
+| <video src="https://github.com/user-attachments/assets/466eddff-f720-4f99-94d5-5e123e4c302c" autoplay loop muted playsinline style="max-width: 300px;"></video> | [LeIsaac-SO101-PickOrange-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/pick_orange/pick_orange_env_cfg.py)<br /><br />[LeIsaac-SO101-PickOrange-Direct-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/pick_orange/direct/pick_orange_env.py)                                                                                                                                                                                                                        | 拾取三个橙子并将其放入盘中，然后将机械臂重置到静止状态。                                                  | 单臂 SO101 Follower                                |
+| <video src="https://github.com/user-attachments/assets/1e4eb83a-0b38-40fb-a0b2-ddb0fe201e6d" autoplay loop muted playsinline style="max-width: 300px;"></video> | [LeIsaac-SO101-LiftCube-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/lift_cube/lift_cube_env_cfg.py)<br /><br />[LeIsaac-SO101-LiftCube-Direct-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/lift_cube/direct/lift_cube_env.py)                                                                                                                                                                                                                                    | 抬起红色方块。                                                                                            | 单臂 SO101 Follower                                |
+| <video src="https://github.com/user-attachments/assets/e49d8f1c-dcc9-412b-a88f-100680d8a45b" autoplay loop muted playsinline style="max-width: 300px;"></video> | [LeIsaac-SO101-CleanToyTable-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/clean_toy_table/clean_toy_table_env_cfg.py)<br /><br />[LeIsaac-SO101-CleanToyTable-BiArm-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/clean_toy_table/clean_toy_table_bi_arm_env_cfg.py)<br /><br />[LeIsaac-SO101-CleanToyTable-BiArm-Direct-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/clean_toy_table/direct/clean_toy_table_bi_arm_env.py) | 拾取两个字母 e 物体并放入盒中，然后将机械臂重置到静止状态。                                               | 单臂 SO101 Follower<br /><br />双臂 SO101 Follower |
+| <video src="https://github.com/user-attachments/assets/e29a0f8a-9286-4ce6-b45d-342c3d3ba754" autoplay loop muted playsinline style="max-width: 300px;"></video> | [LeIsaac-SO101-FoldCloth-BiArm-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/fold_cloth/fold_cloth_bi_arm_env_cfg.py)<br /><br />[LeIsaac-SO101-FoldCloth-BiArm-Direct-v0](https://github.com/LightwheelAI/leisaac/blob/main/source/leisaac/leisaac/tasks/fold_cloth/direct/fold_cloth_bi_arm_env.py)                                                                                                                                                                                                    | 折叠布料，然后将机械臂重置到静止状态。<br /><br />_注意：只有此任务中的 DirectEnv 支持 `check_success`。_ | 双臂 SO101 Follower                                |
+
+# 在 LeRobot 中通过一行代码直接加载 LeIsaac
+
+> EnvHub：通过 Hugging Face 共享 LeIsaac 环境
+
+[EnvHub](https://huggingface.co/docs/lerobot/envhub) 是 LeRobot 提供的可复现环境 Hub，可以通过一行代码启动已打包的仿真环境，立即开展实验，也可以发布自定义任务供社区使用。
+
+LeIsaac 支持 EnvHub，因此只需几条命令即可使用或共享任务。
+
+<video
+  controls
+  src="https://github.com/user-attachments/assets/687666f5-ebe0-421d-84a0-eb86116ac5f8"
+  style={{ width: "100%", maxWidth: "960px", borderRadius: "8px" }}
+/>
+
+## 开始使用：环境设置
+
+运行以下命令设置代码环境：
+
+```bash
+# 参考「开始使用/安装」部分，先安装 leisaac
+conda create -n leisaac_envhub python=3.11
+conda activate leisaac_envhub
+
+conda install -c "nvidia/label/cuda-12.8.1" cuda-toolkit
+pip install -U torch==2.7.0 torchvision==0.22.0 --index-url https://download.pytorch.org/whl/cu128
+pip install 'leisaac[isaaclab] @ git+https://github.com/LightwheelAI/leisaac.git#subdirectory=source/leisaac' --extra-index-url https://pypi.nvidia.com
+
+# 安装 lerobot
+pip install lerobot==0.4.1
+
+# 修复 numpy 版本
+pip install numpy==1.26.0
+```
+
+## 使用示例
+
+EnvHub 为所有 LeIsaac 支持的任务提供统一接口。下面的示例会加载 `so101_pick_orange`，演示随机动作运行和交互式遥操作。
+
+### 随机动作
+
+<details>
+<summary>点击展开代码示例</summary>
+
+```python
+# envhub_random_action.py
+
+import torch
+from lerobot.envs import make_env
+
+# 从 Hub 加载
+envs_dict = make_env("LightwheelAI/leisaac_env:envs/so101_pick_orange.py", n_envs=1, trust_remote_code=True)
+
+# 访问环境
+suite_name = next(iter(envs_dict))
+sync_vector_env = envs_dict[suite_name][0]
+# 从同步向量化环境中获取 Isaac 环境
+env = sync_vector_env.envs[0].unwrapped
+
+# 像使用普通 gym 环境一样使用
+obs, info = env.reset()
+
+while True:
+    action = torch.tensor(env.action_space.sample())
+    obs, reward, terminated, truncated, info = env.step(action)
+    if terminated or truncated:
+        obs, info = env.reset()
+
+env.close()
+```
+
+</details>
+
+```bash
+python envhub_random_action.py
+```
+
+运行后应能看到 SO101 机械臂在完全随机的指令下摆动。
+
+### 遥操作
+
+LeRobot 的遥操作栈可以驱动仿真机械臂。
+
+连接 SO101 Leader 控制器，然后运行以下标定命令。
+
+```bash
+lerobot-calibrate \
+    --teleop.type=so101_leader \
+    --teleop.port=/dev/ttyACM0 \
+    --teleop.id=leader
+```
+
+然后启动遥操作脚本。
+
+<details>
+<summary>点击展开代码示例</summary>
+
+```python
+# envhub_teleop_example.py
+
+import logging
+import time
+import gymnasium as gym
+
+from dataclasses import asdict, dataclass
+from pprint import pformat
+
+from lerobot.teleoperators import (  # noqa: F401
+    Teleoperator,
+    TeleoperatorConfig,
+    make_teleoperator_from_config,
+    so_leader,
+    bi_so_leader,
+)
+from lerobot.utils.robot_utils import precise_sleep
+from lerobot.utils.utils import init_logging
+from lerobot.envs import make_env
+
+
+@dataclass
+class TeleoperateConfig:
+    teleop: TeleoperatorConfig
+    env_name: str = "so101_pick_orange"
+    fps: int = 60
+
+
+@dataclass
+class EnvWrap:
+    env: gym.Env
+
+
+def make_env_from_leisaac(env_name: str = "so101_pick_orange"):
+    envs_dict = make_env(
+        f'LightwheelAI/leisaac_env:envs/{env_name}.py',
+        n_envs=1,
+        trust_remote_code=True
+    )
+    suite_name = next(iter(envs_dict))
+    sync_vector_env = envs_dict[suite_name][0]
+    env = sync_vector_env.envs[0].unwrapped
+
+    return env
+
+
+def teleop_loop(teleop: Teleoperator, env: gym.Env, fps: int):
+    from leisaac.devices.action_process import preprocess_device_action
+    from leisaac.assets.robots.lerobot import SO101_FOLLOWER_MOTOR_LIMITS
+    from leisaac.utils.env_utils import dynamic_reset_gripper_effort_limit_sim
+
+    env_wrap = EnvWrap(env=env)
+
+    obs, info = env.reset()
+    while True:
+        loop_start = time.perf_counter()
+        if env.cfg.dynamic_reset_gripper_effort_limit:
+            dynamic_reset_gripper_effort_limit_sim(env, 'so101leader')
+
+        raw_action = teleop.get_action()
+        processed_action = preprocess_device_action(
+            dict(
+                so101_leader=True,
+                joint_state={
+                    k.removesuffix(".pos"): v for k, v in raw_action.items()},
+                motor_limits=SO101_FOLLOWER_MOTOR_LIMITS),
+            env_wrap
+        )
+        obs, reward, terminated, truncated, info = env.step(processed_action)
+        if terminated or truncated:
+            obs, info = env.reset()
+
+        dt_s = time.perf_counter() - loop_start
+        precise_sleep(max(1 / fps - dt_s, 0.0))
+        loop_s = time.perf_counter() - loop_start
+        print(f"\ntime: {loop_s * 1e3:.2f}ms ({1 / loop_s:.0f} Hz)")
+
+
+def teleoperate(cfg: TeleoperateConfig):
+    init_logging()
+    logging.info(pformat(asdict(cfg)))
+
+    teleop = make_teleoperator_from_config(cfg.teleop)
+    env = make_env_from_leisaac(cfg.env_name)
+
+    teleop.connect()
+    if hasattr(env, 'initialize'):
+        env.initialize()
+    try:
+        teleop_loop(teleop=teleop, env=env, fps=cfg.fps)
+    except KeyboardInterrupt:
+        pass
+    finally:
+        teleop.disconnect()
+        env.close()
+
+
+def main():
+    teleoperate(TeleoperateConfig(
+        teleop=so_leader.SO101LeaderConfig(
+            port="/dev/ttyACM0",
+            id='leader',
+            use_degrees=False,
+        ),
+        env_name="so101_pick_orange",
+        fps=60,
+    ))
+
+
+if __name__ == "__main__":
+    main()
+
+```
+
+</details>
+
+```bash
+python envhub_teleop_example.py
+```
+
+运行脚本后，即可使用实体 Leader 设备操作仿真机械臂。
+
+## ☁️ 云端仿真（无需 GPU）
+
+如果没有本地 GPU 或合适的驱动，可以在云端运行 LeIsaac，无需本地配置。LeIsaac 开箱即用地支持 **NVIDIA Brev**，可直接在浏览器中获得已配置的环境。
+
+👉 **从这里开始：** [https://lightwheelai.github.io/leisaac/docs/cloud_simulation/nvidia_brev](https://lightwheelai.github.io/leisaac/docs/cloud_simulation/nvidia_brev)
+
+实例部署完成后，只需打开 **80 端口（HTTP）** 的链接，即可启动 **Visual Studio Code Server**（默认密码：`password`）。随后可以直接在浏览器中运行仿真、编辑代码并查看 IsaacLab 环境。
+
+**无需 GPU、驱动或本地安装，点击即可运行。**
+
+## 补充说明
+
+EnvHub 的覆盖范围与 LeIsaac 任务保持一致。目前支持：
+
+- `so101_pick_orange`
+- `so101_lift_cube`
+- `so101_clean_toytable`
+- `bi_so101_fold_cloth`
+
+调用 `make_env` 时，可以通过指定不同脚本切换任务，例如：
+
+```python
+envs_dict_pick_orange = make_env("LightwheelAI/leisaac_env:envs/so101_pick_orange.py", n_envs=1, trust_remote_code=True)
+envs_dict_lift_cube = make_env("LightwheelAI/leisaac_env:envs/so101_lift_cube.py", n_envs=1, trust_remote_code=True)
+envs_dict_clean_toytable = make_env("LightwheelAI/leisaac_env:envs/so101_clean_toytable.py", n_envs=1, trust_remote_code=True)
+envs_dict_fold_cloth = make_env("LightwheelAI/leisaac_env:envs/bi_so101_fold_cloth.py", n_envs=1, trust_remote_code=True)
+```
+
+注意：使用 `bi_so101_fold_cloth` 时，获取环境后、执行其他操作前，应立即调用 `initialize()`：
+
+<details>
+<summary>点击展开代码示例</summary>
+
+```python
+import torch
+from lerobot.envs import make_env
+
+# 从 Hub 加载
+envs_dict = make_env("LightwheelAI/leisaac_env:envs/bi_so101_fold_cloth.py", n_envs=1, trust_remote_code=True)
+
+# 访问环境
+suite_name = next(iter(envs_dict))
+sync_vector_env = envs_dict[suite_name][0]
+# 从同步向量化环境中获取 Isaac 环境
+env = sync_vector_env.envs[0].unwrapped
+
+# 注意：先调用 initialize()
+env.initialize()
+
+# 对环境执行其他操作……
+```
+
+</details>


### PR DESCRIPTION
## Summary

- Translate `envhub.mdx` and `envhub_leisaac.mdx` into Simplified Chinese (`zh-Hans`).
- Add both pages to `docs/source/zh-hans/_toctree.yml` under the Simulation section.
- Preserve MDX structure, commands, identifiers, URLs, and technical terminology.

Related issue: #3290

## Validation

- Targeted Markdown/YAML/prettier/typos checks passed.
- Clean zh-Hans documentation build passed with internal links resolved.